### PR TITLE
Fixed floating point precision issue.

### DIFF
--- a/src/sequences.ts
+++ b/src/sequences.ts
@@ -113,9 +113,11 @@ export function createRandomSequenceFloat() : void {
 
 export function createSequence(start : number, nValues : number, stepSize : number) : number[] {
     let seq = [];
+    let precision = parseFloat(stepSize).toString();
+    precision = precision.substr(precision.indexOf(".") + 1).length;
 
     for (let i = 0; i < nValues; ++i) {
-        seq.push(start + i * stepSize);
+        seq.push((start + i * stepSize).toFixed(precision));
     }
 
     return seq;


### PR DESCRIPTION
Issue Description:
If you enter start #: 2.01, step: 0.01, for like 4 entries, you will get something like this:
2.01
2.0199999999999996
2.03
2.0399999999999996

Solution I proposed:
Fetch the count of characters after the decimal point. Use that number as the number of decimal places count to round to.
You first cast to float, just to remove any extra redundant zeros at the end of the user input (step).

Comments:
 - I don't really know TypeScript, and the changes I added are purely in JS. Not sure if it's gonna work.
 - Need to add checks on user input.